### PR TITLE
Add IAM validation for PR

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,6 +4,9 @@ on:
       CHECK_LINT:
         type: boolean
         default: true
+      CHECK_IAM:
+        type: boolean
+        default: true        
       node-version:
         type: number
         required: false
@@ -20,6 +23,13 @@ jobs:
       node-version: ${{ inputs.node-version }}
     secrets:
       NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+  Check-IAM:
+    if: ${{ inputs.CHECK_IAM }}
+    uses: ./.github/workflows/step-check-iam.yml
+    with:
+      BRANCH: ${{ github.head_ref }}
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}    
   Test:
     uses: ./.github/workflows/step-test-pull-request.yml
     with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -27,9 +27,7 @@ jobs:
     if: ${{ inputs.CHECK_IAM }}
     uses: ./.github/workflows/step-check-iam.yml
     with:
-      BRANCH: ${{ github.head_ref }}
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}    
+      BRANCH: ${{ github.head_ref }}   
   Test:
     uses: ./.github/workflows/step-test-pull-request.yml
     with:

--- a/.github/workflows/step-check-iam.yml
+++ b/.github/workflows/step-check-iam.yml
@@ -1,0 +1,24 @@
+on:
+  workflow_call:
+    inputs:
+      CHECK_IAM:
+        type: boolean
+        default: true
+      branch:
+        type: string
+        required: true
+    secrets:
+      GITHUB_TOKEN:
+        required: true
+jobs:
+  Check-IAM:
+    if: ${{ inputs.CHECK_IAM }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3      
+    - name: Run validation
+      uses:  mathem-se/iam-template-analyzer@main
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH: ${{ inputs.branch }}

--- a/.github/workflows/step-check-iam.yml
+++ b/.github/workflows/step-check-iam.yml
@@ -7,13 +7,14 @@ on:
       branch:
         type: string
         required: true
-    secrets:
-      GITHUB_TOKEN:
-        required: true
+
 jobs:
   Check-IAM:
     if: ${{ inputs.CHECK_IAM }}
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
     - name: Checkout
       uses: actions/checkout@v3      

--- a/.github/workflows/step-check-iam.yml
+++ b/.github/workflows/step-check-iam.yml
@@ -12,9 +12,6 @@ jobs:
   Check-IAM:
     if: ${{ inputs.CHECK_IAM }}
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
     steps:
     - name: Checkout
       uses: actions/checkout@v3      

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ jobs:
     uses: mathem-se/gh-workflows-node/.github/workflows/pull-request.yml@main
     with:
       CHECK_LINT: false #if you don't want to check lint (defaults to true)
+      CHECK_IAM: false #if you don't want to validate IAM permissions (defaults to true)
     secrets:
       NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGE_READ_ONLY}}
 ```


### PR DESCRIPTION
- Does a workflow_call to `mathem-se/iam-template-analyzer@main` which steps through the template-file and find resources containing `'*'` and actions containing `:*`.
- Add these as comments to the PR since this is not least privilege permissions.
- Set `CHECK_IAM` to false to opt out from this validation.
- Also adds to DynamoDB table who acts on diff if a new resource is added.

Example below:

![image](https://github.com/mathem-se/gh-workflows-node/assets/56074741/339c54b2-8e4b-410d-8047-4009efc97af4)
