### PR TITLE
Remove capabilites from sam deploy due to overriding samconfig.toml

### DIFF
--- a/.github/workflows/step-release-aws.yml
+++ b/.github/workflows/step-release-aws.yml
@@ -68,7 +68,6 @@ jobs:
           --no-confirm-changeset \
           --no-fail-on-empty-changeset \
           --stack-name ${{ github.event.repository.name }} \
-          --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
           --region ${{ inputs.AWS_DEPLOY_REGION }} \
           --s3-prefix ${{ github.event.repository.name }} \
           --resolve-s3 \


### PR DESCRIPTION
We had a situation where we needed to use `CAPABILITY_AUTO_EXPAND` but unfortunately the parameter below `--capabilities` was overriding samconfig.toml. We tested removing it from a different branch and deploy against that. Worked fine.

All repos containg a samconfig.toml so this should be fine. You'll receive a very clear error-message if you would miss some capabilities.