### PR TITLE
fix: multi stack deploy

### DIFF
--- a/.github/workflows/step-release-aws.yml
+++ b/.github/workflows/step-release-aws.yml
@@ -79,12 +79,6 @@ jobs:
       - name: Deploy
         shell: bash
         run: |
-          if [ ! -z "${{ inputs.sam-template-file }}" ]
-          then
-              template_file_param="--template-file ${{ inputs.sam-template-file }}"
-          else
-              template_file_param=""
-          fi
           sam deploy \
           --no-confirm-changeset \
           --no-fail-on-empty-changeset \
@@ -97,5 +91,4 @@ jobs:
           --config-env ${{ inputs.environment }} \
           --tags \
             'domain=${{ inputs.domain }} \
-            team=${{ inputs.team }}' \
-          $template_file_param 
+            team=${{ inputs.team }}'


### PR DESCRIPTION
It seems you should not specify `-t --template-file, --template` property when using `sam deploy`. Doing so will copy the whole folder structure and deploy your lambda. By removing `-t --template-file, --template` from `sam deploy` we are deploying from the `sam build` output folder which is `./aws-sam/*`.

[Source](https://github.com/aws/aws-sam-cli/issues/2664#issuecomment-974742776)